### PR TITLE
added new line before the fixture import message

### DIFF
--- a/lib/import_fixtures
+++ b/lib/import_fixtures
@@ -9,7 +9,7 @@
 Importer.print = function(config, database, name, additive, quiet){
   Importer._quiet = quiet;
   var filepath  = config.__basedir+(config.fixtures)+'/'+name+'/'
-    , msg = "beginning "+name+" import into "+database+" database"
+    , msg = "\nbeginning "+name+" import into "+database+" database"
     ;
   console.log(msg.cyan);
   Importer.config = config;


### PR DESCRIPTION
This is an aesthetic modification for when migrit is used with protractor.
<img width="315" alt="screen shot 2015-08-28 at 4 43 41 pm" src="https://cloud.githubusercontent.com/assets/1185267/9556690/b6421f28-4da4-11e5-825a-07e348827d8b.png">

