### PR TITLE
processing exit status for better external error handling

### DIFF
--- a/bin/migrit
+++ b/bin/migrit
@@ -224,4 +224,6 @@ config.then(function(c){
   console.log(err.stack);
 
   console.log("\nHave you run `migrit init` for this project?");
+  
+  process.exit(1);
 });


### PR DESCRIPTION
bash scripts were unable to process the error log message as a proper error code. now they can